### PR TITLE
fix: UX language update from 'speakers' to 'participants' (#25)

### DIFF
--- a/build.html
+++ b/build.html
@@ -661,7 +661,7 @@ async function loadSpeakers() {
 function renderSpeakerList() {
   const list = document.getElementById('speakerList');
   if (!speakersData.length) {
-    list.innerHTML = '<p style="color:var(--muted);font-size:13px;padding:8px 0">No speakers yet — be the first to sign up!</p>';
+    list.innerHTML = '<p style="color:var(--muted);font-size:13px;padding:8px 0">No participants yet — be the first to sign up!</p>';
     return;
   }
   list.innerHTML = speakersData.map(sp => {

--- a/public/build.html
+++ b/public/build.html
@@ -957,7 +957,7 @@ async function loadSpeakers() {
 function renderSpeakerList() {
   const list = document.getElementById('speakerList');
   if (!speakersData.length) {
-    list.innerHTML = '<p style="color:var(--muted);font-size:13px;padding:8px 0">No speakers yet — be the first to sign up!</p>';
+    list.innerHTML = '<p style="color:var(--muted);font-size:13px;padding:8px 0">No participants yet — be the first to sign up!</p>';
     return;
   }
   list.innerHTML = speakersData.map(sp => {

--- a/public/event.html
+++ b/public/event.html
@@ -272,7 +272,7 @@ async function loadEvent() {
 
       <!-- Tabs -->
       <div class="event-tabs">
-        <button class="event-tab active" onclick="switchTab('lineup')">Lineup (${speakers.length})</button>
+        <button class="event-tab active" onclick="switchTab('lineup')">Lineup (${speakers.length} participants)</button>
         <button class="event-tab" onclick="switchTab('bounties')">Bounties (${bounties.length})</button>
       </div>
 
@@ -287,7 +287,7 @@ async function loadEvent() {
                  </div>`
               : `<div class="empty-cta">
                   <div class="empty-cta-icon">🎤</div>
-                  <h3>No speakers yet — be the first to present!</h3>
+                  <h3>No participants yet — be the first to present!</h3>
                   <p>Share your project, demo something you built, or talk about what you're learning.</p>
                   <button class="btn btn-primary" onclick="document.getElementById('signupSection').style.display='block';document.getElementById('signupSection').scrollIntoView({behavior:'smooth'})">Sign Up to Present</button>
                  </div>`)}


### PR DESCRIPTION
🌌 **Atlas Contribution**

This PR addresses issue #25 by refining the UX language to be more inclusive of bounty hunters and participants.

### Changes:
- Updated empty state text from 'No speakers yet' to 'No participants yet' across multiple views.
- Updated the lineup tab count label to include the 'participants' suffix for better context.

*Note: The underlying data structures remain named 'speakers' for database compatibility, but the UI now reflects the intended user context.*