### PR TITLE
fix: let projects attach presentations after creation

### DIFF
--- a/public/project.html
+++ b/public/project.html
@@ -92,6 +92,27 @@
   </div>
 </div>
 
+<!-- Link Existing Presentation Modal -->
+<div class="modal-overlay" id="linkExistingDeckModal">
+  <div class="modal-content" style="max-width:440px">
+    <button class="modal-close" onclick="this.closest('.modal-overlay').classList.remove('open')">&times;</button>
+    <div class="modal-title">Link Existing Presentation</div>
+    <div class="form-group">
+      <label>Choose a deck you've already uploaded</label>
+      <select id="existingDeckSelect"><option value="">Loading decks…</option></select>
+      <div id="existingDeckCopy" style="font-size:0.78rem;color:var(--muted2);margin-top:6px">Attach a deck from the DEX so this project can show it later.</div>
+    </div>
+    <div class="form-group">
+      <label>Version Label <span style="color:var(--muted2);font-weight:400">(optional)</span></label>
+      <input type="text" id="existingDeckLabel" placeholder="e.g. Demo Day v1, Investor Cut…">
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="this.closest('.modal-overlay').classList.remove('open')">Cancel</button>
+      <button class="btn btn-primary" id="linkExistingDeckBtn" onclick="submitExistingDeckLink()">Attach Presentation</button>
+    </div>
+  </div>
+</div>
+
 <!-- Project Zap Modal -->
 <div class="modal-overlay" id="zapModal">
   <div class="modal-content" style="max-width:440px;text-align:center">
@@ -717,15 +738,60 @@ function switchPresentationsView(deckId, entryPoint) {
   if (iframe) iframe.src = `/presentations/${deckId}/${entryPoint}`;
 }
 
+function openProjectDeckActionModal(modalId) {
+  const modal = document.getElementById(modalId);
+  if (!modal) return;
+  if (modalId === 'linkExistingDeckModal') loadExistingDeckOptions();
+  modal.classList.add('open');
+}
+
+async function loadExistingDeckOptions() {
+  const sel = document.getElementById('existingDeckSelect');
+  const copy = document.getElementById('existingDeckCopy');
+  if (!sel) return;
+  sel.innerHTML = '<option value="">Loading decks…</option>';
+  try {
+    const res = await fetch('/api/decks?limit=48');
+    const data = await res.json();
+    const decks = data.decks || [];
+    sel.innerHTML = '';
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = decks.length ? 'Choose a presentation…' : 'No uploaded decks available';
+    sel.appendChild(defaultOption);
+    decks.forEach((deck) => {
+      const option = document.createElement('option');
+      option.value = deck.id;
+      option.textContent = deck.title || deck.filename || deck.id;
+      sel.appendChild(option);
+    });
+    if (copy) {
+      copy.textContent = decks.length
+        ? 'Pick a deck from the DEX to attach it as the current project presentation.'
+        : 'Upload a deck to the DEX first, then come back here to attach it.';
+    }
+  } catch {
+    sel.innerHTML = '<option value="">Unable to load decks</option>';
+    if (copy) copy.textContent = 'Could not load your available decks right now.';
+  }
+}
+
 function renderPresentationsEmptyState(canManage) {
   const manageCopy = canManage
-    ? 'Upload the first presentation version to populate this tab.'
+    ? 'Add the first presentation now by uploading one or linking a deck you already published.'
     : 'This project has not added any presentation decks yet.';
+  const actionRow = canManage
+    ? `<div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;margin-top:14px">
+        <button class="btn btn-sm" onclick="openProjectDeckActionModal('uploadVersionModal')">Upload Presentation</button>
+        <button class="btn btn-sm" onclick="openProjectDeckActionModal('linkExistingDeckModal')">Link Existing Presentation</button>
+      </div>`
+    : '';
   return `
     <div class="empty-state" style="padding:36px 20px;border:1px solid var(--border);border-radius:var(--radius-lg);background:var(--glass)">
       <div class="icon">🪐</div>
       <h3>No presentations yet</h3>
       <p>${manageCopy}</p>
+      ${actionRow}
     </div>`;
 }
 
@@ -825,8 +891,11 @@ async function loadDeckVersions(project) {
       if (overviewEmbed) overviewEmbed.innerHTML = `<div style="margin-bottom:20px">${embedHtml}</div>`;
     }
 
-    const uploadBtn = canManage
-      ? `<button class="btn btn-sm" style="font-size:0.7rem" onclick="document.getElementById('uploadVersionModal').classList.add('open')">+ New Version</button>`
+    const manageButtons = canManage
+      ? `<div style="display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end">
+          <button class="btn btn-sm" style="font-size:0.7rem" onclick="openProjectDeckActionModal('uploadVersionModal')">Upload Presentation</button>
+          <button class="btn btn-sm" style="font-size:0.7rem" onclick="openProjectDeckActionModal('linkExistingDeckModal')">Link Existing Presentation</button>
+        </div>`
       : '';
 
     const count = versions.length || (project.deck_id ? 1 : 0);
@@ -834,7 +903,7 @@ async function loadDeckVersions(project) {
       <div style="margin-bottom:16px">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
           <span style="font-family:var(--font-mono);font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--accent)">Version History (${count})</span>
-          ${uploadBtn}
+          ${manageButtons}
         </div>
         <div style="display:flex;flex-direction:column;gap:6px">${items}</div>
       </div>`;
@@ -867,15 +936,39 @@ async function submitVersionUpload() {
     document.getElementById('uploadVersionModal').classList.remove('open');
     fileInput.value = ''; document.getElementById('versionLabel').value = '';
     document.getElementById('versionFileName').textContent = 'Drop file or click to browse';
-    loadDeckVersions(currentProject);
+    loadProject();
   } catch(e) { alert('Upload failed: ' + e.message); }
   finally { btn.disabled = false; btn.textContent = 'Upload'; document.getElementById('versionUploadProgress').style.display = 'none'; }
+}
+
+async function submitExistingDeckLink() {
+  const deckId = document.getElementById('existingDeckSelect').value;
+  const label = document.getElementById('existingDeckLabel').value.trim();
+  if (!deckId) return alert('Please choose a presentation');
+  const btn = document.getElementById('linkExistingDeckBtn');
+  btn.disabled = true; btn.textContent = 'Attaching…';
+  try {
+    const r = await fetch('/api/projects/' + projectId + '/decks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deck_id: deckId, label: label || null })
+    });
+    if (!r.ok) { const e = await r.json().catch(()=>({})); alert(e.error || 'Attach failed'); return; }
+    document.getElementById('linkExistingDeckModal').classList.remove('open');
+    document.getElementById('existingDeckSelect').value = '';
+    document.getElementById('existingDeckLabel').value = '';
+    loadProject();
+  } catch(e) {
+    alert('Attach failed: ' + e.message);
+  } finally {
+    btn.disabled = false; btn.textContent = 'Attach Presentation';
+  }
 }
 
 async function setCurrentVersion(projId, versionId) {
   try {
     const r = await fetch('/api/projects/' + projId + '/decks/' + versionId + '/set-current', { method: 'PATCH' });
-    if (r.ok) loadDeckVersions(currentProject);
+    if (r.ok) loadProject();
     else { const e = await r.json().catch(()=>({})); alert(e.error || 'Failed'); }
   } catch { alert('Failed to set version'); }
 }

--- a/server.js
+++ b/server.js
@@ -1042,6 +1042,9 @@ function canManageProject(project, user) {
   return !!project.user_id && user.id === project.user_id;
 }
 
+function syncProjectDeckPointer(projectId, deckId) {
+  db.prepare('UPDATE projects SET deck_id = ? WHERE id = ?').run(deckId || null, projectId);
+}
 
 function requireAdmin(req, res, next) {
   if (req.user && req.user.is_admin) return next();
@@ -3031,6 +3034,7 @@ app.post('/api/projects/:id/decks', requireAuth, (req, res) => {
   const id = crypto.randomUUID();
   db.prepare('INSERT INTO project_decks (id, project_id, deck_id, version, label, is_current) VALUES (?, ?, ?, ?, ?, 1)')
     .run(id, req.params.id, deck_id, version, resolvedLabel);
+  syncProjectDeckPointer(req.params.id, deck_id);
 
   // Mark deck hidden so it won't appear in gallery
   db.prepare('UPDATE decks SET hidden = 1 WHERE id = ?').run(deck_id);
@@ -3088,6 +3092,7 @@ app.post('/api/projects/:id/decks/upload', requireAuth, upload.single('file'), a
     const versionId = crypto.randomUUID();
     db.prepare('INSERT INTO project_decks (id, project_id, deck_id, version, label, is_current) VALUES (?, ?, ?, ?, ?, 1)')
       .run(versionId, req.params.id, deckId, version, resolvedLabel);
+    syncProjectDeckPointer(req.params.id, deckId);
 
     generateThumbnail(deckId, entryPoint).catch(err => {
       console.warn(`[thumb] ${deckId}: ${err.message}`);
@@ -3123,7 +3128,10 @@ app.delete('/api/projects/:id/decks/:version_id', requireAuth, (req, res) => {
   if (entry.is_current) {
     const prev = db.prepare('SELECT * FROM project_decks WHERE project_id = ? ORDER BY version DESC LIMIT 1')
       .get(req.params.id);
-    if (prev) db.prepare('UPDATE project_decks SET is_current = 1 WHERE id = ?').run(prev.id);
+    if (prev) {
+      db.prepare('UPDATE project_decks SET is_current = 1 WHERE id = ?').run(prev.id);
+      syncProjectDeckPointer(req.params.id, prev.deck_id);
+    }
   }
 
   res.json({ ok: true });
@@ -3143,6 +3151,7 @@ app.patch('/api/projects/:id/decks/:version_id/set-current', requireAuth, (req, 
 
   db.prepare('UPDATE project_decks SET is_current = 0 WHERE project_id = ?').run(req.params.id);
   db.prepare('UPDATE project_decks SET is_current = 1 WHERE id = ?').run(req.params.version_id);
+  syncProjectDeckPointer(req.params.id, entry.deck_id);
 
   res.json({ ok: true });
 });

--- a/tests/project-presentation-management.test.js
+++ b/tests/project-presentation-management.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (...parts) => fs.readFileSync(path.join(ROOT, ...parts), 'utf8');
+
+test('project page lets owners add a presentation later by uploading or linking an existing deck', () => {
+  const projectHtml = read('public', 'project.html');
+  assert.match(projectHtml, /Link Existing Presentation/);
+  assert.match(projectHtml, /fetch\('\/api\/decks\?limit=48'\)/);
+  assert.match(projectHtml, /No presentations yet[\s\S]*Upload Presentation/);
+  assert.match(projectHtml, /No presentations yet[\s\S]*Link Existing Presentation/);
+});
+
+test('project presentation version routes keep the project deck pointer synced to the current presentation', () => {
+  const server = read('server.js');
+  assert.match(server, /function syncProjectDeckPointer\(projectId, deckId\) \{/);
+  assert.match(server, /app\.post\('\/api\/projects\/:id\/decks',[\s\S]*syncProjectDeckPointer\(req\.params\.id, deck_id\);/);
+  assert.match(server, /app\.post\('\/api\/projects\/:id\/decks\/upload',[\s\S]*syncProjectDeckPointer\(req\.params\.id, deckId\);/);
+  assert.match(server, /app\.patch\('\/api\/projects\/:id\/decks\/:version_id\/set-current',[\s\S]*syncProjectDeckPointer\(req\.params\.id, entry\.deck_id\);/);
+  assert.match(server, /if \(entry\.is_current\) \{[\s\S]*syncProjectDeckPointer\(req\.params\.id, prev\.deck_id\);/);
+});

--- a/tests/remediation-batch4.test.js
+++ b/tests/remediation-batch4.test.js
@@ -53,7 +53,9 @@ test('project presentations tab shows an explicit empty state when no deck exist
   const projectHtml = read('public', 'project.html');
   assert.match(projectHtml, /function renderPresentationsEmptyState/);
   assert.match(projectHtml, /No presentations yet/);
-  assert.match(projectHtml, /Upload the first presentation version to populate this tab/);
+  assert.match(projectHtml, /Add the first presentation now by uploading one or linking a deck you already published/);
+  assert.match(projectHtml, /Upload Presentation/);
+  assert.match(projectHtml, /Link Existing Presentation/);
 });
 
 test('bounty timeline inactive steps and create bounty CTA have stronger visual treatment', () => {


### PR DESCRIPTION
## Summary
- let project owners add a presentation later from the project page
- support both uploading a new presentation and linking an existing deck from the DEX
- keep the project current deck pointer synced when versions are added, switched, or promoted after deletion

## Test Plan
- node --check server.js
- node --test tests/project-presentation-management.test.js tests/project-owner-authorization.test.js
- node --test --test-name-pattern="project presentations tab shows an explicit empty state when no deck exists" tests/remediation-batch4.test.js

Fixes the missing post-creation presentation attachment flow reported in chat.