### PR TITLE
fix: normalize project hero image presentation

### DIFF
--- a/public/build.html
+++ b/public/build.html
@@ -1605,7 +1605,7 @@ function renderProjectCards(projects) {
     const editBannerBtn = isOwner ? `<button class="proj-banner-edit-btn" onclick="event.stopPropagation(); triggerBannerUpload('${esc(p.id)}')" title="${p.banner_url ? 'Change banner' : 'Add banner'}">📷</button>` : '';
     return `
       <div class="project-card project-card-${statusTone}" id="proj-${esc(p.id)}" onclick="if(!event.target.closest('.project-upvote')&&!event.target.closest('.spk-link')&&!event.target.closest('.proj-zap-btn')&&!event.target.closest('.proj-banner-edit-btn'))window.location='/project/'+this.id.replace('proj-','')" style="cursor:pointer">
-        <div style="position:relative">
+        <div class="project-card-media">
           <img class="project-card-visual" src="${visualSrc}" alt="">
           ${editBannerBtn}
         </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -693,14 +693,22 @@ a:hover { color: var(--accent); }
   padding: 16px 20px 20px;
   display: flex; flex-direction: column; flex: 1;
 }
+.project-card-media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  background: var(--glass);
+  flex-shrink: 0;
+}
 .project-card-visual {
   width: 100%;
-  height: 140px;
+  height: 100%;
   object-fit: cover;
   object-position: center center;
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border-radius: 0;
   display: block;
-  flex-shrink: 0;
   background: var(--glass);
 }
 .project-card:hover { border-color: var(--border2); transform: translateY(-2px); box-shadow: 0 8px 32px rgba(0,0,0,.3); }

--- a/public/profile.html
+++ b/public/profile.html
@@ -806,11 +806,13 @@ function renderProjectCard(p) {
   const satsLabel = p.total_sats_received > 0
     ? `<span style="font-family:var(--font-mono);font-size:0.68rem;color:var(--btc-bright);opacity:.85">⚡${Number(p.total_sats_received).toLocaleString()}</span>`
     : '';
-  const visualSrc = p.thumbnail_url || p.banner_url || projectVisual(p.name, p.category, 400, 120);
+  const visualSrc = p.banner_url || p.thumbnail_url || projectVisual(p.name, p.category, 400, 120);
   const statusTone = window.LunarUiRules ? window.LunarUiRules.getProjectStatusTone(p.status) : 'building';
   return `
     <div class="project-card project-card-${statusTone}" onclick="if(!event.target.closest('.project-upvote')&&!event.target.closest('.spk-link'))window.location='/project/${p.id}'" style="cursor:pointer">
-      <img class="project-card-visual" src="${visualSrc}" alt="">
+      <div class="project-card-media">
+        <img class="project-card-visual" src="${visualSrc}" alt="">
+      </div>
       <div class="project-card-body">
         <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:4px;gap:10px">
           <div class="project-name">${esc(p.name)}</div>

--- a/server.js
+++ b/server.js
@@ -37,11 +37,27 @@ const ADMIN_LN_ADDRESS = 'lunarpad@21m.lol';
 const LNBITS_URL = process.env.LNBITS_URL || 'https://21m.lol';
 const LNBITS_INVOICE_KEY = process.env.LNBITS_INVOICE_KEY || '';
 const LNBITS_ADMIN_KEY = process.env.LNBITS_ADMIN_KEY || '';
-const LNBITS_WEBHOOK_SECRET=process.env.LNBITS_WEBHOOK_SECRET || '';
+const LNBITS_WEBHOOK_SECRET = process.env.LNBITS_WEBHOOK_SECRET || '';
 const EARLY_ADOPTER_CUTOFF_AT = new Date('2026-04-10T23:59:59.999Z');
+const PROJECT_HERO_WIDTH = 1600;
+const PROJECT_HERO_HEIGHT = 900;
 
 for (const dir of [UPLOADS_DIR, THUMBNAILS_DIR, TEMP_DIR, AVATARS_DIR]) {
   fs.mkdirSync(dir, { recursive: true });
+}
+
+async function normalizeProjectHeroImage(filePath) {
+  if (!sharp) return;
+  const processed = await sharp(filePath)
+    .rotate()
+    .resize(PROJECT_HERO_WIDTH, PROJECT_HERO_HEIGHT, {
+      fit: 'cover',
+      position: 'centre',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 86, mozjpeg: true })
+    .toBuffer();
+  fs.writeFileSync(filePath, processed);
 }
 
 const FALLBACK_EVENT_TIMEZONES = [
@@ -1955,12 +1971,9 @@ app.post('/api/projects/:id/banner', requireAuth, bannerUpload.single('banner'),
       return res.status(500).json({ error: 'Failed to save banner' });
     }
   }
-  if (sharp) {
-    try {
-      const processed = await sharp(destPath).resize(800, 450, { fit: 'cover', position: 'centre' }).toBuffer();
-      fs.writeFileSync(destPath, processed);
-    } catch (_) {}
-  }
+  try {
+    await normalizeProjectHeroImage(destPath);
+  } catch (_) {}
   const bannerUrl = '/avatars/' + filename;
   db.prepare('UPDATE projects SET banner_url = ? WHERE id = ?').run(bannerUrl, req.params.id);
   res.json({ ok: true, banner_url: bannerUrl });

--- a/tests/project-hero-images.test.js
+++ b/tests/project-hero-images.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (...parts) => fs.readFileSync(path.join(ROOT, ...parts), 'utf8');
+
+test('project hero pipeline defines explicit normalization constants and helper', () => {
+  const server = read('server.js');
+  assert.match(server, /const PROJECT_HERO_WIDTH = 1600;/);
+  assert.match(server, /const PROJECT_HERO_HEIGHT = 900;/);
+  assert.match(server, /async function normalizeProjectHeroImage\(filePath\) \{/);
+  assert.match(server, /await normalizeProjectHeroImage\(destPath\);/);
+});
+
+test('project hero media uses a reusable 16:9 wrapper and consistent object positioning', () => {
+  const css = read('public', 'css', 'style.css');
+  const buildHtml = read('public', 'build.html');
+  const profileHtml = read('public', 'profile.html');
+
+  assert.match(css, /\.project-card-media \{[\s\S]*aspect-ratio:\s*16\s*\/\s*9;[\s\S]*overflow:\s*hidden;/);
+  assert.match(css, /\.project-card-visual \{[\s\S]*height:\s*100%;[\s\S]*object-fit:\s*cover;[\s\S]*object-position:\s*center center;/);
+  assert.match(buildHtml, /class="project-card-media"/);
+  assert.match(profileHtml, /class="project-card-media"/);
+});


### PR DESCRIPTION
## Summary
- add explicit project hero normalization constants and helper on the server
- normalize uploaded project banners to a reusable 16:9 hero format
- switch project cards to a reusable media wrapper so mixed image sizes crop consistently in build and profile surfaces

## Test Plan
- node --check server.js
- node --test tests/project-hero-images.test.js tests/project-presentation-management.test.js tests/project-owner-authorization.test.js
- node --test --test-name-pattern="projects sparse states and project detail explain status and support actions|projects view makes tag overflow discoverable and uses stronger repo demo labels" tests/remediation-batch4.test.js

Closes #91